### PR TITLE
fix oauth

### DIFF
--- a/fe/src/components/GoogleCallback.jsx
+++ b/fe/src/components/GoogleCallback.jsx
@@ -9,6 +9,7 @@ import {
   setProfileToLocalStorage,
   setRefreshTokenToLocalStorage,
 } from "../utils/auth";
+import userApis from "../apis/users.apis";
 
 const GoogleCallback = () => {
   const navigate = useNavigate();
@@ -17,28 +18,32 @@ const GoogleCallback = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const access_token = urlParams.get("access_token");
     const refresh_token = urlParams.get("refresh_token");
-    if (access_token) {
+    setAccessTokenToLocalStorage(access_token);
+    setRefreshTokenToLocalStorage(refresh_token);
+    const fetchUserProfile = async (userId) => {
       try {
-        const decoded = decodeToken(access_token);
-        const userData = {
-          id: decoded.id,
-          name: decoded.unique_name,
-          email: decoded.email,
-          avartar: decoded.avartar,
-          role: decoded.role,
-          isModerator: decoded.isModerator,
-        };
-
+        const response = await userApis.getMe(userId);
+        const userData = response.data.result;
         setIsAuthenticated(true);
         setProfile(userData);
         setRole(userData.role);
-        setAccessTokenToLocalStorage(access_token);
-        setRefreshTokenToLocalStorage(refresh_token);
+
         setProfileToLocalStorage(userData);
         toast.success("Đăng nhập thành công!");
         navigate(path.home);
       } catch (error) {
-        toast.error(error.message);
+        toast.error("Lấy thông tin người dùng thất bại");
+        navigate(path.login);
+      }
+    };
+
+    if (access_token) {
+      try {
+        const decoded = decodeToken(access_token);
+        const userId = decoded.user_id || decoded.id;
+        fetchUserProfile(userId);
+      } catch (error) {
+        toast.error("Token không hợp lệ!");
         navigate(path.login);
       }
     } else {

--- a/fe/src/constants/path.js
+++ b/fe/src/constants/path.js
@@ -28,6 +28,7 @@ const path = {
   community: "/community",
   nearBy: "/artists/nearby",
   registerRequest: "/artist-requests",
+  oauth: "/oauth",
 };
 
 export default path;

--- a/fe/src/route/Router.jsx
+++ b/fe/src/route/Router.jsx
@@ -167,7 +167,7 @@ const AppRouter = () => {
       ),
     },
     {
-      path: "/oauth",
+      path: path.oauth,
       element: <GoogleCallback />,
     },
     // protect route - admin

--- a/fe/src/utils/http.js
+++ b/fe/src/utils/http.js
@@ -52,7 +52,7 @@ class Http {
     this.instance.interceptors.response.use(
       (response) => {
         const { url } = response.config;
-        if (url.includes(loginUrl)) {
+        if (url.includes(loginUrl) || url.includes("/login/google")) {
           this.accessToken = response.data.result.access_token;
           this.refreshToken = response.data.result.refresh_token;
           setAccessTokenToLocalStorage(this.accessToken);


### PR DESCRIPTION
## Summary by Sourcery

Refactor and harden the Google OAuth callback flow: store tokens up front, validate and fetch the user profile from the API, improve error handling and redirection, centralize the OAuth route using a path constant, and adjust the HTTP interceptor to capture Google login tokens.

Bug Fixes:
- Store access and refresh tokens before decoding or fetching the profile to avoid missing data.
- Show descriptive error toasts and redirect to login when token validation or profile retrieval fails.
- Include the "/login/google" endpoint in the HTTP interceptor so Google login tokens are properly captured.

Enhancements:
- Refactor GoogleCallback to use userApis.getMe for retrieving user details instead of decoding the JWT payload.
- Add and use a centralized path.oauth constant for the OAuth callback route in Router.jsx and constants/path.js.