### PR TITLE
delete post & tooltip of chattime

### DIFF
--- a/fe/src/apis/posts.apis.js
+++ b/fe/src/apis/posts.apis.js
@@ -7,6 +7,8 @@ const postApis = {
   getAllReactions: (post_id) => http.get(`/${postRoute}/${post_id}/reactions`),
   addPost: (payload) => http.post(`${postRoute}/add-post`, payload),
   getAllPosts: () => http.get(`${postRoute}/all`),
+  deletePost: (post_id) =>
+    http.delete(`/${postRoute}/delete-post`, { data: { post_id } }),
 };
 
 export default postApis;

--- a/fe/src/components/ArtistProfile.jsx
+++ b/fe/src/components/ArtistProfile.jsx
@@ -43,6 +43,13 @@ export default function ArtistProfile({ portfolio }) {
     formState: { errors },
   } = useForm({
     resolver: yupResolver(updateArtistProfileSchema),
+    defaultValues: {
+      name: portfolio.name,
+      bio: portfolio.bio,
+      email: portfolio.email,
+      phone_number: portfolio.phone_number,
+      portfolio_urls: urls,
+    },
   });
   useEffect(() => {
     if (portfolio) {
@@ -110,6 +117,7 @@ export default function ArtistProfile({ portfolio }) {
               label="Họ tên:"
               {...register("name")}
               size="small"
+              InputLabelProps={{ shrink: true }}
               fullWidth
               error={!!errors.name}
               helperText={errors.name?.message || " "}
@@ -121,6 +129,7 @@ export default function ArtistProfile({ portfolio }) {
               margin="normal"
               fullWidth
               label="Số điện thoại: "
+              InputLabelProps={{ shrink: true }}
               {...register("phone_number")}
               error={!!errors.phone_number}
               helperText={errors.phone_number?.message || " "}
@@ -143,6 +152,7 @@ export default function ArtistProfile({ portfolio }) {
               fullWidth
               multiline
               minRows={3}
+              InputLabelProps={{ shrink: true }}
               {...register("bio")}
               error={!!errors.bio}
               helperText={errors.bio?.message || " "}
@@ -157,6 +167,7 @@ export default function ArtistProfile({ portfolio }) {
             disabled
             sx={{ cursor: "not-allowed" }}
             error={!!errors.email}
+            InputLabelProps={{ shrink: true }}
             helperText={errors.email?.message || " "}
           />
           <Box>
@@ -177,6 +188,7 @@ export default function ArtistProfile({ portfolio }) {
                   value={item}
                   size="small"
                   fullWidth
+                  InputLabelProps={{ shrink: true }}
                   onChange={(e) => handleUrlChange(e, index)}
                   InputProps={{
                     readOnly: editableIndex !== index,

--- a/fe/src/components/ChatBox.jsx
+++ b/fe/src/components/ChatBox.jsx
@@ -1,5 +1,12 @@
 /* eslint-disable react/prop-types */
-import { Box, TextField, IconButton, Typography, Avatar } from "@mui/material";
+import {
+  Box,
+  TextField,
+  IconButton,
+  Typography,
+  Avatar,
+  Tooltip,
+} from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import SendIcon from "@mui/icons-material/Send";
 import React, { useEffect, useState } from "react";
@@ -118,6 +125,16 @@ const ChatBox = ({ onClose, artist, client }) => {
               }}
             >
               <Typography variant="body2">{msg.message}</Typography>
+              <Tooltip
+                title={`Gửi lúc: ${new Date(msg.created_at).toLocaleString("vi-VN")}`}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{ display: "block", marginTop: 0.5 }}
+                >
+                  {new Date(msg.created_at).toLocaleTimeString("vi-VN")}
+                </Typography>
+              </Tooltip>
             </Box>
           );
         })}

--- a/fe/src/components/ChatWindow.jsx
+++ b/fe/src/components/ChatWindow.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from "react";
-import { Box, Typography, TextField, IconButton } from "@mui/material";
+import { Box, Typography, TextField, IconButton, Tooltip } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
 import chatLineApis from "../apis/chatLines.apis";
 import { HttpStatusCode } from "axios";
@@ -87,7 +87,11 @@ export default function ChatWindow({ room, isClient }) {
                 color: isMyMessage ? "white" : "black",
               }}
             >
-              <Typography variant="body2">{msg.message}</Typography>
+              <Tooltip
+                title={`Gửi lúc: ${new Date(msg.created_at).toLocaleString("vi-VN")}`}
+              >
+                <Typography variant="body2">{msg.message}</Typography>
+              </Tooltip>
             </Box>
           );
         })}

--- a/fe/src/pages/artist/ArtistPostManagement.jsx
+++ b/fe/src/pages/artist/ArtistPostManagement.jsx
@@ -10,6 +10,10 @@ import {
   Modal,
   Typography,
   IconButton,
+  DialogContent,
+  DialogTitle,
+  DialogActions,
+  Dialog,
 } from "@mui/material";
 import toast from "react-hot-toast";
 import { useForm } from "react-hook-form";
@@ -23,6 +27,7 @@ import HttpStatusCode from "../../constants/httpStatus";
 import { useDropzone } from "react-dropzone";
 import RemoveIcon from "@mui/icons-material/Remove";
 import postApis from "../../apis/posts.apis";
+import CancelIcon from "@mui/icons-material/Cancel";
 
 export default function ArtistPostManagement() {
   const { profile } = useContext(AppContext);
@@ -31,6 +36,31 @@ export default function ArtistPostManagement() {
   const [open, setOpen] = useState(false);
   const [files, setFiles] = useState([]);
   const [previews, setPreviews] = useState([]);
+  const [openAlert, setOpenAlert] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState(null);
+
+  const handleClose = () => {
+    setOpenAlert(false);
+  };
+
+  const handleRequestDelete = (post_id) => {
+    setDeleteTargetId(post_id);
+    setOpenAlert(true);
+  };
+
+  const handleDeleteConfirmed = async () => {
+    if (!deleteTargetId) return;
+    setOpenAlert(true);
+    const response = await postApis.deletePost(deleteTargetId);
+    if (response.status === HttpStatusCode.Ok) {
+      toast.success(response.data.message, {
+        position: "top-center",
+      });
+      fetchPosts();
+    }
+    setOpenAlert(false);
+    setDeleteTargetId(null);
+  };
 
   const onDrop = (acceptedFiles) => {
     const currentFiles = watch("media_url") || [];
@@ -181,11 +211,101 @@ export default function ArtistPostManagement() {
                       height="420"
                       style={{ objectFit: "cover" }}
                     />
+                    <CancelIcon
+                      onClick={() => handleRequestDelete(post.id)}
+                      sx={{
+                        width: 30,
+                        height: 30,
+                        position: "absolute",
+                        top: -15,
+                        right: -10,
+                        cursor: "pointer",
+                        ":hover": {
+                          opacity: 0.8,
+                        },
+                      }}
+                    />
                   </Box>
                 )}
               </Grid>
             ))}
           </Grid>
+          <Dialog
+            open={openAlert}
+            onClose={handleClose}
+            keepMounted
+            TransitionComponent={Fade}
+            transitionDuration={300}
+            BackdropProps={{
+              sx: {
+                backdropFilter: "blur(8px)",
+                backgroundColor: "rgba(0,0,0,0.2)",
+              },
+            }}
+            PaperProps={{
+              sx: {
+                backgroundColor: "rgba(255, 255, 255, 0.1)",
+                borderRadius: "20px",
+                border: "1px solid rgba(255, 255, 255, 0.2)",
+                boxShadow: "0 12px 32px rgba(0, 0, 0, 0.35)",
+                color: "#fff",
+                px: 3,
+                py: 2,
+                transition: "all 0.3s ease",
+              },
+            }}
+          >
+            <DialogTitle
+              id="alert-dialog-title"
+              sx={{
+                fontWeight: 600,
+                fontSize: 22,
+                color: "rgba(255, 255, 255, 0.95)",
+              }}
+            >
+              Xác nhận trước khi xóa
+            </DialogTitle>
+
+            <DialogContent>
+              <Typography
+                variant="body1"
+                sx={{ color: "rgba(255, 255, 255, 0.85)", mb: 1 }}
+              >
+                Bạn có chắc chắn muốn xóa bài đăng này?
+              </Typography>
+            </DialogContent>
+
+            <DialogActions sx={{ gap: 1 }}>
+              <Button
+                onClick={handleClose}
+                variant="outlined"
+                sx={{
+                  borderColor: "rgba(255, 255, 255, 0.3)",
+                  color: "#ddd",
+                  "&:hover": {
+                    borderColor: "#aaa",
+                    backgroundColor: "rgba(255, 255, 255, 0.1)",
+                  },
+                }}
+              >
+                Hủy
+              </Button>
+              <Button
+                onClick={handleDeleteConfirmed}
+                color="error"
+                variant="contained"
+                sx={{
+                  backgroundColor: "#ff4d4f",
+                  color: "#fff",
+                  "&:hover": {
+                    backgroundColor: "#e53935",
+                  },
+                }}
+              >
+                Xóa
+              </Button>
+            </DialogActions>
+          </Dialog>
 
           <Modal
             open={open}


### PR DESCRIPTION
## Summary by Sourcery

Implement post deletion feature with confirmation dialog and toast feedback, initialize ArtistProfile form with portfolio defaults and shrink input labels, and display message timestamps via tooltips in chat components.

New Features:
- Enable deleting artist posts through a cancel icon with a confirmation dialog and success toast
- Show message send timestamps in ChatBox and ChatWindow via tooltips
- Add deletePost method to the posts API client

Enhancements:
- Prepopulate ArtistProfile form fields with portfolio data and apply shrinking labels