### PR TITLE
post detail modal as artist mode

### DIFF
--- a/fe/src/components/PostModal.jsx
+++ b/fe/src/components/PostModal.jsx
@@ -39,7 +39,9 @@ export default function PostModal({
   setMyReaction,
   reactions,
   comments,
+  profileType,
 }) {
+  console.log("post: ", selectedPost);
   const [comment, setComment] = useState("");
   const { profile: contextProfile } = useContext(AppContext);
 
@@ -122,7 +124,11 @@ export default function PostModal({
             <Box sx={{ mb: 2 }}>
               <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}>
                 <Avatar
-                  src={profile.avatar_url}
+                  src={
+                    profileType === "artist"
+                      ? profile.artist_avatar_url
+                      : profile.avatar_url
+                  }
                   sx={{ width: 48, height: 48 }}
                 />
 
@@ -131,7 +137,9 @@ export default function PostModal({
                     variant="subtitle1"
                     sx={{ fontWeight: 600, lineHeight: 1.2 }}
                   >
-                    {profile.name}
+                    {profileType === "artist"
+                      ? profile.artist_name
+                      : profile.name}
                   </Typography>
 
                   <Typography variant="caption" color="text.secondary">

--- a/fe/src/pages/ArtistDetail.jsx
+++ b/fe/src/pages/ArtistDetail.jsx
@@ -598,6 +598,7 @@ export default function ArtistDetail() {
                   setMyReaction={setMyReaction}
                   reactions={reactions}
                   comments={comments}
+                  profileType={"client"}
                 />
               </CustomTabPanel>
             </Box>

--- a/fe/src/pages/artist/ArtistPostManagement.jsx
+++ b/fe/src/pages/artist/ArtistPostManagement.jsx
@@ -29,6 +29,7 @@ import { useDropzone } from "react-dropzone";
 import RemoveIcon from "@mui/icons-material/Remove";
 import postApis from "../../apis/posts.apis";
 import CancelIcon from "@mui/icons-material/Cancel";
+import PostModal from "../../components/PostModal";
 
 export default function ArtistPostManagement() {
   const { profile } = useContext(AppContext);
@@ -39,11 +40,20 @@ export default function ArtistPostManagement() {
   const [previews, setPreviews] = useState([]);
   const [openAlert, setOpenAlert] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState(null);
+  const [openDetail, setOpenDetail] = useState(false);
+  const [selectedPost, setSelectedPost] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [selectedMedia, setSelectedMedia] = useState([]);
+  const [reactions, setReactions] = useState([]);
+  const [myReaction, setMyReaction] = useState(null);
+  const [currentModal, setCurrentModal] = useState(null);
 
   const handleClose = () => {
     setOpenAlert(false);
   };
-
+  const closeModal = () => {
+    setCurrentModal(null);
+  };
   const handleRequestDelete = (post_id) => {
     setDeleteTargetId(post_id);
     setOpenAlert(true);
@@ -105,13 +115,13 @@ export default function ArtistPostManagement() {
     },
   });
   useEffect(() => {
-    const previews = watch("media_urls_preview") || [];
+    const previews = watch("media_url_preview") || [];
     return () => {
       previews.forEach((item) => {
         if (item?.preview) URL.revokeObjectURL(item.preview);
       });
     };
-  }, [watch("media_urls_preview")]);
+  }, [watch("media_url_preview")]);
 
   const handleRemoveFile = (index) => {
     const files = watch("media_url") || [];
@@ -185,6 +195,29 @@ export default function ArtistPostManagement() {
     customPosts = [...posts, ...Array(emptySlots).fill({ id: "empty" })];
   }
 
+  const getAllReactions = async (postId) => {
+    try {
+      const response = await postApis.getAllReactions(postId);
+      if (response.status === HttpStatusCode.Ok) {
+        setReactions(response.data.result);
+        response.data.result.map((item) => {
+          if (item.user_id === profile.id) {
+            setMyReaction(item);
+          }
+        });
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const getAllComments = async (postId) => {
+    const response = await postApis.getAllComments(postId);
+    if (response.status === HttpStatusCode.Ok) {
+      setComments(response.data.result);
+    }
+  };
+
   return (
     <Box sx={{ margin: 4 }}>
       {loading ? (
@@ -202,17 +235,25 @@ export default function ArtistPostManagement() {
             {customPosts.map((post, idx) => (
               <Grid item xs={12} sm={6} md={4} key={idx}>
                 {post.id === "empty" ? (
-                  <Box sx={{ width: 300, height: 420 }} />
+                  <Box sx={{ width: "100%", height: 420 }} />
                 ) : (
-                  <Box position="relative" sx={{ cursor: "pointer" }}>
+                  <Box
+                    position="relative"
+                    sx={{ height: 420, cursor: "pointer" }}
+                  >
                     <img
+                      loading="lazy"
                       src={post.media_url?.[0]}
                       alt="post"
-                      width="100%"
-                      height="420"
-                      style={{ objectFit: "cover", display: "block" }}
+                      style={{
+                        width: "100%",
+                        minWidth: 300,
+                        maxWidth: 320,
+                        height: "100%",
+                        objectFit: "cover",
+                        display: "block",
+                      }}
                     />
-
                     {/* Overlay hiển thị khi hover */}
                     <Box
                       className="hover-overlay"
@@ -235,6 +276,14 @@ export default function ArtistPostManagement() {
                           opacity: 1,
                         },
                       }}
+                      onClick={() => {
+                        setSelectedPost(post);
+                        setSelectedMedia(post.media_url);
+                        setOpenDetail(true);
+                        getAllComments(post.id);
+                        getAllReactions(post.id);
+                        setCurrentModal("post");
+                      }}
                     >
                       <Box display="flex" alignItems="center" gap={0.5}>
                         <FavoriteIcon fontSize="small" />
@@ -245,7 +294,6 @@ export default function ArtistPostManagement() {
                         <Typography>{post.Reaction.length || 0}</Typography>
                       </Box>
                     </Box>
-
                     {/* Nút xóa */}
                     <CancelIcon
                       onClick={() => handleRequestDelete(post.id)}
@@ -467,6 +515,21 @@ export default function ArtistPostManagement() {
               </Box>
             </Fade>
           </Modal>
+          {selectedPost && openDetail && (
+            <PostModal
+              selectedPost={selectedPost}
+              getAllComments={getAllComments}
+              currentModal={currentModal}
+              closeModal={closeModal}
+              selectedMedia={selectedMedia}
+              profile={profile}
+              myReaction={myReaction}
+              setMyReaction={setMyReaction}
+              reactions={reactions}
+              comments={comments}
+              profileType={"artist"}
+            />
+          )}
         </>
       )}
     </Box>

--- a/fe/src/pages/artist/ArtistServiceManagement.jsx
+++ b/fe/src/pages/artist/ArtistServiceManagement.jsx
@@ -670,112 +670,120 @@ export default function ArtistServiceManagement() {
             }}
           >
             <Grid container spacing={2}>
-              {services.map((item, index) => (
-                <Grid item xs={12} sm={6} md={4} key={index}>
-                  <Card
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      setIsOpenDetail(true);
-                      setSelectedService(item);
-                    }}
-                    sx={{
-                      width: 250,
-                      height: 350,
-                      display: "flex",
-                      flexDirection: "column",
-                      borderRadius: "15px",
-                      overflow: "hidden",
-                      ":hover": {
-                        opacity: "80%",
-                        cursor: "pointer",
-                      },
-                    }}
-                  >
-                    <CardMedia
-                      component="img"
-                      height="200"
-                      image={item.thumbnail}
-                      alt={item.service_name}
-                      sx={{
-                        transition:
-                          "transform 0.3s ease, background-color 0.3s ease",
-                        objectFit: "cover",
-                        "&:hover": {
-                          transform: "scale(1.05)",
-                        },
-                      }}
-                    />
-
-                    <Box
-                      sx={{
-                        flex: "1 1 auto",
-                        display: "flex",
-                        flexDirection: "column",
-                        px: 2,
-                        py: 1,
-                      }}
-                    >
-                      <Typography
-                        variant="h6"
-                        sx={{
-                          fontWeight: 600,
-                          fontSize: 16,
-                          lineHeight: 1.3,
-                          mb: 1,
-                          display: "-webkit-box",
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: "vertical",
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                        }}
-                      >
-                        {item.service_name}
-                      </Typography>
-
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{
-                          flexShrink: 0,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          display: "-webkit-box",
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: "vertical",
-                          fontSize: 13,
-                          lineHeight: "1.4em",
-                          minHeight: "2.8em",
-                        }}
-                      >
-                        {item.description}
-                      </Typography>
-
-                      <Typography
-                        sx={{ mt: "auto", fontWeight: 600, fontSize: 14 }}
-                      >
-                        Từ {formatCurrency(item.min_price)}
-                        {" - "}
-                        {formatCurrency(item.max_price)} VND
-                      </Typography>
-                    </Box>
-
-                    <CardActions
-                      sx={{ justifyContent: "space-between", px: 2, pb: 2 }}
-                    >
-                      <Button
-                        size="small"
-                        variant="outlined"
+              {services.length > 0 ? (
+                <>
+                  {services.map((item, index) => (
+                    <Grid item xs={12} sm={6} md={4} key={index}>
+                      <Card
                         onClick={(event) => {
                           event.stopPropagation();
+                          setIsOpenDetail(true);
+                          setSelectedService(item);
+                        }}
+                        sx={{
+                          width: 250,
+                          height: 350,
+                          display: "flex",
+                          flexDirection: "column",
+                          borderRadius: "15px",
+                          overflow: "hidden",
+                          ":hover": {
+                            opacity: "80%",
+                            cursor: "pointer",
+                          },
                         }}
                       >
-                        Chỉnh sửa
-                      </Button>
-                    </CardActions>
-                  </Card>
-                </Grid>
-              ))}
+                        <CardMedia
+                          component="img"
+                          height="200"
+                          image={item.thumbnail}
+                          alt={item.service_name}
+                          sx={{
+                            transition:
+                              "transform 0.3s ease, background-color 0.3s ease",
+                            objectFit: "cover",
+                            "&:hover": {
+                              transform: "scale(1.05)",
+                            },
+                          }}
+                        />
+
+                        <Box
+                          sx={{
+                            flex: "1 1 auto",
+                            display: "flex",
+                            flexDirection: "column",
+                            px: 2,
+                            py: 1,
+                          }}
+                        >
+                          <Typography
+                            variant="h6"
+                            sx={{
+                              fontWeight: 600,
+                              fontSize: 16,
+                              lineHeight: 1.3,
+                              mb: 1,
+                              display: "-webkit-box",
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: "vertical",
+                              whiteSpace: "nowrap",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {item.service_name}
+                          </Typography>
+
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{
+                              flexShrink: 0,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              display: "-webkit-box",
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: "vertical",
+                              fontSize: 13,
+                              lineHeight: "1.4em",
+                              minHeight: "2.8em",
+                            }}
+                          >
+                            {item.description}
+                          </Typography>
+
+                          <Typography
+                            sx={{ mt: "auto", fontWeight: 600, fontSize: 14 }}
+                          >
+                            Từ {formatCurrency(item.min_price)}
+                            {" - "}
+                            {formatCurrency(item.max_price)} VND
+                          </Typography>
+                        </Box>
+
+                        <CardActions
+                          sx={{ justifyContent: "space-between", px: 2, pb: 2 }}
+                        >
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                            }}
+                          >
+                            Chỉnh sửa
+                          </Button>
+                        </CardActions>
+                      </Card>
+                    </Grid>
+                  ))}
+                </>
+              ) : (
+                <Typography color="text.secondary">
+                  Chưa có dịch vụ makeup nào.
+                </Typography>
+              )}
             </Grid>
           </Box>
           {isOpenDetail && (


### PR DESCRIPTION
## Summary by Sourcery

Enable artists to open posts in a detail modal with comments and reactions, introduce an empty-state message for services, and streamline UI styling and media cleanup in artist management pages

New Features:
- Integrate PostModal into artist post management to enable viewing post details in a modal
- Fetch and display comments and reactions for a post when opened by an artist

Enhancements:
- Add profileType prop to PostModal to render correct avatar and name for artists and clients
- Show an empty-state message when no services are available in ArtistServiceManagement
- Refine grid item sizing and styling for service and post cards in artist views
- Refactor media preview cleanup logic in ArtistPostManagement