### PR TITLE
fix

### DIFF
--- a/fe/src/utils/http.js
+++ b/fe/src/utils/http.js
@@ -31,8 +31,8 @@ class Http {
     this.refreshToken = getRefreshTokenFromLocalStorage();
     this.refreshTokenRequest = null;
     this.instance = axios.create({
-      baseURL: "http://localhost:3000",
-      //   baseURL: import.meta.env.VITE_API_BASE_URL,
+      //  baseURL: "http://localhost:3000",
+      baseURL: import.meta.env.VITE_API_BASE_URL,
       timeout: 10000,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Configure axios HTTP client to use VITE_API_BASE_URL environment variable instead of hardcoded localhost URL