### PR TITLE
fix api body

### DIFF
--- a/fe/src/apis/artists.apis.js
+++ b/fe/src/apis/artists.apis.js
@@ -5,7 +5,7 @@ export const artistUrl = "artists";
 
 const artistApis = {
   registerArtist: (payload) => http.post(`${artistUrl}/register`, payload),
-  getArtistProfile: (artist_id) => http.get(`${artistUrl}/${artist_id}/me`),
+  getArtistProfile: () => http.get(`${artistUrl}/me`),
   updateArtistProfile: (artist_id, body) =>
     http.patch(`${artistUrl}/${artist_id}/me`, body),
   getPortfolioIcon: (domain, size) => {

--- a/fe/src/components/GoogleCallback.jsx
+++ b/fe/src/components/GoogleCallback.jsx
@@ -3,7 +3,6 @@ import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import path from "../constants/path";
 import { AppContext } from "../contexts/app.context";
-import { decodeToken } from "../utils/jwt";
 import {
   setAccessTokenToLocalStorage,
   setProfileToLocalStorage,
@@ -20,9 +19,9 @@ const GoogleCallback = () => {
     const refresh_token = urlParams.get("refresh_token");
     setAccessTokenToLocalStorage(access_token);
     setRefreshTokenToLocalStorage(refresh_token);
-    const fetchUserProfile = async (userId) => {
+    const fetchUserProfile = async () => {
       try {
-        const response = await userApis.getMe(userId);
+        const response = await userApis.getMe();
         const userData = response.data.result;
         setIsAuthenticated(true);
         setProfile(userData);
@@ -32,17 +31,15 @@ const GoogleCallback = () => {
         toast.success("Đăng nhập thành công!");
         navigate(path.home);
       } catch (error) {
-        // toast.error("Lấy thông tin người dùng thất bại");
-        // navigate(path.login);
+        toast.error("Lấy thông tin người dùng thất bại");
+        navigate(path.login);
         console.log(error);
       }
     };
 
     if (access_token) {
       try {
-        const decoded = decodeToken(access_token);
-        const userId = decoded.user_id || decoded.id;
-        fetchUserProfile(userId);
+        fetchUserProfile();
       } catch (error) {
         toast.error("Token không hợp lệ!");
         navigate(path.login);

--- a/fe/src/components/layout/Sidebar.jsx
+++ b/fe/src/components/layout/Sidebar.jsx
@@ -35,7 +35,7 @@ export default function Sidebar() {
   useEffect(() => {
     const getArtistProfile = async () => {
       try {
-        const response = await artistApis.getArtistProfile(profile.artist_id);
+        const response = await artistApis.getArtistProfile();
         if (response.status === HttpStatusCode.Ok) {
           setPortfolioUrl(response.data.result.portfolio_url || []);
           setArtistProfile(response.data.result);

--- a/fe/src/pages/artist/ArtistPortfolio.jsx
+++ b/fe/src/pages/artist/ArtistPortfolio.jsx
@@ -51,7 +51,7 @@ export default function ArtistPortfolio() {
 
   const getArtistPortfolio = async () => {
     try {
-      const response = await artistApis.getArtistProfile(profile.artist_id);
+      const response = await artistApis.getArtistProfile();
       setPortfolio(response.data.result);
     } catch (error) {
       toast.error(error.message || error.response.data.message);


### PR DESCRIPTION
## Summary by Sourcery

Update profile fetching to use authenticated endpoints and streamline error handling

Bug Fixes:
- Re-enable error toast and login redirect when user profile fetch fails in GoogleCallback

Enhancements:
- Simplify user profile fetch by removing ID parameter and using userApis.getMe without arguments
- Refactor artistApis.getArtistProfile to call /artists/me endpoint and remove artist_id parameter
- Update Sidebar and ArtistPortfolio components to call getArtistProfile with no arguments
- Remove token decoding logic for user ID retrieval in GoogleCallback