### PR TITLE
fix error cannot login

### DIFF
--- a/fe/src/components/GoogleCallback.jsx
+++ b/fe/src/components/GoogleCallback.jsx
@@ -8,7 +8,7 @@ import {
   setProfileToLocalStorage,
   setRefreshTokenToLocalStorage,
 } from "../utils/auth";
-import userApis from "../apis/users.apis";
+import http from "../utils/http";
 
 const GoogleCallback = () => {
   const navigate = useNavigate();
@@ -22,7 +22,11 @@ const GoogleCallback = () => {
     const fetchUserProfile = async () => {
       try {
         await Promise.resolve();
-        const response = await userApis.getMe();
+        const response = await http.get(`${import.meta.env.VITE_API_URL}/me`, {
+          headers: {
+            Authorization: `Bearer ${access_token}`,
+          },
+        });
         const userData = response.data.result;
         setIsAuthenticated(true);
         setProfile(userData);


### PR DESCRIPTION
## Summary by Sourcery

Fix login error by changing the user profile fetch to use the shared HTTP utility with a bearer token and environment-based endpoint

Bug Fixes:
- Include the access token in the Authorization header when fetching the user profile to enable successful login.

Enhancements:
- Refactor GoogleCallback component to use the common http utility and VITE_API_URL environment variable instead of userApis.